### PR TITLE
Attempt to address Ctrl-C issue

### DIFF
--- a/download_Live.py
+++ b/download_Live.py
@@ -100,6 +100,9 @@ class LiveStreamDownloader:
             })
             
             return file, filetype
+        except KeyboardInterrupt:
+            self.logger.debug("Keyboard interrupt detected in download_stream")
+            raise
         except Exception as e:
             self.logger.exception("Unexpected error occurred while downloading stream")
             raise
@@ -125,6 +128,9 @@ class LiveStreamDownloader:
                 str(filetype).lower(): file
             })
             return file, filetype
+        except KeyboardInterrupt:
+            self.logger.debug("Keyboard interrupt detected in download_stream_direct")
+            raise
         except Exception as e:
             self.logger.exception("Unexpected error occurred while downloading stream")
             raise
@@ -158,6 +164,9 @@ class LiveStreamDownloader:
                 str(filetype).lower(): file
             })
             return file, filetype
+        except KeyboardInterrupt:
+            self.logger.info("Keyboard interrupt detected in recover_stream")
+            raise
         except Exception as e:
             self.logger.exception("Unexpected error occurred while downloading stream")
             raise
@@ -347,8 +356,9 @@ class LiveStreamDownloader:
                         self.chat_timeout = time.time()
                     while live_chat_thread.is_alive() and not (self.kill_all.is_set() or self.kill_this.is_set()):
                         time.sleep(0.1)
-                
+
             except KeyboardInterrupt as e:
+                self.kill_all.set()
                 self.kill_this.set()
                 self.logger.debug("Keyboard interrupt detected")
                 if len(not_done) > 0:
@@ -359,8 +369,8 @@ class LiveStreamDownloader:
                 executor.shutdown(wait=False,cancel_futures=True)
                 self.logger.debug("Shutdown all threads")
                 self.stats["status"] = "Cancelled"
-                raise        
-                
+                raise
+
         self.stats["status"] = "Muxing"
         self.create_mp4(file_names=self.file_names, info_dict=info_dict, options=options)
             


### PR DESCRIPTION
While waiting for a video to go live with the `--wait-for-video` option, yt-dlp code will prompt the user to press Ctrl-C to re-extract video info if they do not wish to wait for it to happen automatically. The problem is that livestream_dl has a signal handler that gets this first, sets a flag to kill the download, then passes it along. Everything seems fine until the stream goes live and download starts, at which point it is killed.

This PR attempts to address this. The first commit takes a horrible approach with high maintenance burden, and the second one replaces it with a poorly-tested and riskier approach that likely needs refining. Both should result in Ctrl-C performing as expected by users reading the prompt from yt-dlp's messages (currently output at INFO level), and both allow the user to kill the program by pressing Ctrl-C multiple times (which is as it was before, due to the kill event being potentially massively delayed).

Please be careful if merging this PR.