### PR TITLE
Attempt to fix stats line blanking and overwriting

### DIFF
--- a/download_Live.py
+++ b/download_Live.py
@@ -966,7 +966,10 @@ class LiveStreamDownloader:
             blanking_space = ""
             if self._stats_prev_line_len > len(stats_line):
                 blanking_space = " " * (self._stats_prev_line_len - len(stats_line))
+            if self._stats_prev_line_len == 0:
+                print()
             print("\r" + stats_line + blanking_space, end="")
+            self._stats_prev_line_len = len(stats_line)
 
     def add_url_param(self, url: str, key, value) -> str:
         parsed = urlparse(url)


### PR DESCRIPTION
This commit attempts to fix two small issues with the download stats output, which is typically a line that overwrites itself on the console by way of carriage return characters.

When a subsequent line is shorter than the previous one, such as when the download size ticks over from MB to GB, trailing characters will be left on the screen. This is addressed by adding some whitespace as needed to blank it out.

Since the download stats line ends in a '\r', a subsequent log message will overwrite it which can be confusing to read. This is addressed by moving the '\r' to the beginning of download stats lines, which also necessitates moving '\n' to the beginning of (console) log messages.